### PR TITLE
fix(proxy): always use codetabs proxy endpoint

### DIFF
--- a/www/src/proxy_fetch.ts
+++ b/www/src/proxy_fetch.ts
@@ -1,14 +1,7 @@
 export default async function ProxyFetch(rawUrl: string): Promise<Uint8Array> {
-  let url: string;
-  if (rawUrl.endsWith(".html")) {
-    // corsproxy.io doesn't support HTML contents.
-    // Falls back to slower but more reliable codetabs.com.
-    url = `https://api.codetabs.com/v1/proxy/?quest=${encodeURIComponent(
-      rawUrl,
-    )}`;
-  } else {
-    url = `https://corsproxy.io/?url=${encodeURIComponent(rawUrl)}`;
-  }
+  const url = `https://api.codetabs.com/v1/proxy/?quest=${encodeURIComponent(
+    rawUrl,
+  )}`;
   const resp = await fetch(url, {
     method: "GET",
     mode: "cors",


### PR DESCRIPTION
Why:
- corsproxy.io is no longer usable due to paywall gating.
- Branching by file type is unnecessary when both paths should use the same proxy.

What:
- Replace the non-HTML proxy URL with api.codetabs.com in ProxyFetch.
- Remove the conditional branch and set a single codetabs URL for all requests.
- Keep existing fetch behavior and error handling unchanged.

Impact:
- All proxied requests now consistently route through api.codetabs.com.
- Simplifies proxy_fetch.ts and removes dead branching logic.
- No tests were run in this step.