### PR TITLE
chore(ci): bump wasm-pack to 0.14.0

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - name: Install wasm-pack
         run: |
-          cargo install wasm-pack --version 0.13.1
+          cargo install wasm-pack --version 0.14.0
       - uses: actions/setup-node@v6
         with:
           node-version: "22.9.0"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         twiggy-version:
           - "0.8.0"
         wasm-pack-version:
-          - "0.13.1"
+          - "0.14.0"
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Why:
- Keep CI and Pages builds on the latest wasm-pack release.
- Avoid drift from upstream tooling updates.

What:
- Update rust.yml matrix wasm-pack-version from 0.13.1 to 0.14.0.
- Update gh-pages.yml wasm-pack install command from 0.13.1 to 0.14.0.

Impact:
- CI and deploy workflows now install wasm-pack 0.14.0.
- No other workflow behavior was changed.
- Tests were not run locally; verification was limited to config diff checks.
