### PR TITLE
chore(repo): add pre-commit config for issue 35

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-merge-conflict
+
+  - repo: local
+    hooks:
+      - id: cargo-fmt-check
+        name: cargo fmt --all -- --check
+        entry: cargo fmt --all -- --check
+        language: system
+        pass_filenames: false
+        files: '^src/|^Cargo\.(toml|lock)$'
+
+      - id: npm-lint
+        name: npm run lint (www)
+        entry: sh -c 'cd www && npm run lint'
+        language: system
+        pass_filenames: false
+        files: '^www/'
+
+      - id: npm-prettier-check
+        name: npm run test:prettier (www)
+        entry: sh -c 'cd www && npm run test:prettier'
+        language: system
+        pass_filenames: false
+        files: '^www/'

--- a/codex-notes/issue-35-pre-commit-config/plan.md
+++ b/codex-notes/issue-35-pre-commit-config/plan.md
@@ -1,0 +1,95 @@
+# Plan: Issue #35 Add `.pre-commit-config.yaml`
+
+## Overview
+Add a root-level `.pre-commit-config.yaml` with a minimal, low-cost hook set that improves local commit hygiene and aligns with existing CI checks without duplicating heavy test workloads.
+
+Design goals:
+- Introduce pre-commit safely with fast hooks.
+- Reuse existing project tooling for language checks where practical.
+- Pin external hook repositories to immutable commit hashes.
+- Keep scope to one logical change requested by issue #35.
+
+## Files To Change
+- `.pre-commit-config.yaml` (new)
+
+Optional (only if explicitly requested later, not in current scope):
+- `README.md` for setup instructions.
+
+## Detailed Implementation Steps
+1. Select minimal hook categories:
+- Generic text hygiene hooks from `pre-commit-hooks`:
+  - `end-of-file-fixer`
+  - `trailing-whitespace`
+  - `check-yaml`
+  - `check-merge-conflict`
+- Rust formatting check via local hook:
+  - `cargo fmt --all -- --check`
+- TypeScript lint/format checks via local hooks (run in `www/`):
+  - `npm run lint`
+  - `npm run test:prettier`
+
+2. Pin repository hooks by commit hash:
+- Resolve latest `pre-commit-hooks` tag and hash.
+- Use hash in `rev` with inline comment `# frozen: vX.Y.Z`.
+
+3. Configure local hooks for subdirectory-aware execution:
+- Use `entry` commands that execute in `www/` for npm scripts (e.g., `cd www && npm run lint`).
+- Scope file patterns to avoid unnecessary execution where possible.
+
+4. Keep hook cost controlled:
+- Do not add full `cargo test` or `npm test` to pre-commit.
+- Avoid auto-fixing transforms beyond basic text hygiene.
+
+5. Validate configuration syntactically and behaviorally:
+- Run `pre-commit run --all-files`.
+- If hooks fail due to existing code issues, capture failures and remediate only if directly required for this issue scope.
+
+6. Confirm final diff is single-change scoped:
+- Ensure only `.pre-commit-config.yaml` is introduced unless fixing unavoidable hook config issues.
+
+## Alternatives Considered
+1. Generic hooks only (no Rust/TS hooks)
+- Pros: fastest commits, zero toolchain assumptions.
+- Cons: weak value for this repo’s actual quality gates.
+- Rejected: under-delivers compared to current CI expectations.
+
+2. Full CI parity hooks (`cargo test`, `npm test`)
+- Pros: stronger local gate.
+- Cons: high latency; poor commit UX.
+- Rejected: violates minimal/low-cost pre-commit objective.
+
+3. Use language-specific third-party pre-commit repos for Rust/JS
+- Pros: less custom shell wiring.
+- Cons: more external dependencies and maintenance.
+- Rejected: local hooks using existing project scripts are simpler and match current tooling.
+
+## Risks
+- Local environments missing required tools (`pre-commit`, Rust toolchain, Node deps under `www`) can cause hook failures.
+- Running npm hooks from wrong directory would fail; requires explicit `cd www`.
+- Strict lint/format checks may block commits until existing issues are fixed.
+
+## Test Strategy
+- Validate `.pre-commit-config.yaml` parse and hook execution by running:
+  - `pre-commit run --all-files`
+- Spot-check targeted commands:
+  - `cargo fmt --all -- --check`
+  - `cd www && npm run lint`
+  - `cd www && npm run test:prettier`
+- Confirm no unrelated file modifications are introduced by hooks.
+
+## Assumptions
+- Issue #35 expects creation of `.pre-commit-config.yaml` only.
+- Adding minimal Rust/TS checks in pre-commit is acceptable and consistent with repository intent.
+- Using pinned external hook repo commits is desired.
+
+## Open Questions
+- Should README setup instructions (`pre-commit install`) be included in this issue scope?
+- Should Rust/TS checks run at `pre-commit` stage or be moved to `pre-push` for performance?
+
+## Implementation Checklist
+- [x] Determine pinned commit hash for `pre-commit-hooks` and record tag comment.
+- [x] Add root `.pre-commit-config.yaml` with minimal generic hooks.
+- [x] Add local Rust format check hook.
+- [x] Add local TypeScript lint/prettier hooks for `www/`.
+- [x] Run `pre-commit run --all-files` and fix config-level issues if needed.
+- [x] Verify diff remains scoped to issue #35 request.

--- a/codex-notes/issue-35-pre-commit-config/research.md
+++ b/codex-notes/issue-35-pre-commit-config/research.md
@@ -1,0 +1,93 @@
+# Research: Issue #35 Add `.pre-commit-config.yaml`
+
+## Task Context
+- GitHub issue: `koba-e964/tsumeshogi-web-solver#35`
+- Issue title: `Add .pre-commit-config.yaml`
+- Issue body: none
+- Scope inferred from issue title: add root-level pre-commit configuration for this repository.
+
+## Relevant Files and Modules
+- `Cargo.toml`
+  - Rust crate metadata and dependency graph.
+- `.github/workflows/rust.yml`
+  - Rust CI checks currently enforced:
+    - `cargo build`
+    - `cargo test --locked`
+    - `cargo clippy --all-targets --locked`
+    - `cargo fmt -- --check`
+- `www/package.json`
+  - TypeScript/Web checks and scripts:
+    - `npm run lint` -> `eslint .`
+    - `npm run test:prettier` -> `prettier --check src/*.ts?`
+    - `npm test` -> `jest`
+- `.github/workflows/test-ts.yml`
+  - TypeScript CI checks in `www/`:
+    - `npm ci`
+    - `npm run lint`
+    - `npm run test:prettier`
+    - `npm test -- --bail --maxWorkers=100% --watchAll=false --coverage`
+- `.gitignore`
+  - Existing ignore policy; useful to confirm formatting and generated files handling.
+- (Missing currently) `.pre-commit-config.yaml`
+
+## Existing Hook and Git Hook Infrastructure
+- `.pre-commit-config.yaml`: not present.
+- `.git/hooks/pre-commit`: not present.
+- `core.hooksPath` git config: unset.
+
+## Execution Flow and Call Graph (Current)
+- Local developer commits currently do not trigger repository-managed automated checks.
+- Quality gates run in CI only:
+  - Push/PR -> GitHub Actions workflows (`rust.yml`, `test-ts.yml`) execute language-specific checks.
+- Therefore local feedback loop before commit is manual (developer must run tools explicitly).
+
+## Data Structures and Invariants
+- There is no existing pre-commit configuration schema in-repo.
+- CI implies these quality invariants are intended:
+  - Rust code should remain formatted (`cargo fmt --check`).
+  - Rust code should be warning-clean under clippy settings used by CI.
+  - TypeScript code should pass ESLint.
+  - Targeted TS formatting (`src/*.ts?`) should pass Prettier check.
+- Any future pre-commit config should avoid violating existing command assumptions (working directory differences between root and `www/`).
+
+## Existing Architectural Patterns and Conventions
+- Repository is polyglot:
+  - Rust at repository root.
+  - TypeScript frontend under `www/`.
+- CI check separation by language/workflow file.
+- Existing npm scripts indicate preferred command entrypoints for TS checks.
+- GitHub Actions pin policy in this repo uses trusted first-party actions by tag (`actions/*@v6`) and third-party by tag (`dtolnay/rust-toolchain@stable`).
+
+## Naming and Style Conventions
+- YAML files and workflow naming are descriptive and concise.
+- Script names in `www/package.json` are explicit (`lint`, `test:prettier`, `test`).
+- Root README is concise and mostly Japanese text; no current pre-commit setup instructions.
+
+## Error Handling and Operational Constraints
+- Pre-commit runs from repository root by default; hooks must account for subdirectory tooling (`www`).
+- Heavy hooks may degrade commit UX if they run full test suites.
+- Existing skill constraints for pre-commit in this environment require:
+  - Minimal, low-cost checks first.
+  - Prefer repo-based hooks where feasible.
+  - Pin hook repositories to immutable commit hashes.
+
+## Typing and Tooling Conventions
+- Rust: stable toolchain in CI with clippy/rustfmt.
+- TS: npm + eslint/prettier/jest.
+- No evidence of alternative hook frameworks (lefthook/husky) currently in use.
+
+## Potential Pitfalls
+- Duplicating expensive CI checks in pre-commit may slow commits excessively.
+- Running `npm`-based checks from root without path handling may fail if hook config assumes `www/` cwd.
+- Overly broad formatting hooks could modify generated artifacts unintentionally.
+- If pre-commit is not installed locally, config addition alone does not activate hooks.
+
+## Constraints
+- Follow issue scope only: add pre-commit config (single logical change).
+- Keep behavior aligned with existing CI policies.
+- Avoid introducing unrelated refactors.
+
+## Unknowns
+- Exact desired hook breadth (minimal hygiene only vs language-specific lint/format checks).
+- Whether user wants accompanying README note or only config file.
+- Whether local environment has `pre-commit` installed.


### PR DESCRIPTION
Closes #35 
Why:
- Issue #35 requests adding a repository pre-commit configuration.
- The repository had no shared local commit hooks despite existing CI quality checks.

What:
- Added root .pre-commit-config.yaml.
- Added pinned pre-commit-hooks repo (frozen v6.0.0) with basic hygiene hooks.
- Added local hooks for cargo fmt check and www npm lint/prettier checks.
- Added codex-notes/issue-35-pre-commit-config/research.md and plan.md documenting the required research/plan workflow.

Impact:
- Commits now get fast local validation before CI for formatting/linting hygiene.
- No runtime behavior changes to the application.
- Verified by running pre-commit run --all-files successfully.
