### PR TITLE
ci: declare Node version for workflows

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
           cargo install wasm-pack --version 0.15.0
       - uses: actions/setup-node@v6
         with:
-          node-version: "22.9.0"
+          node-version-file: www/package.json
       - run: npm install
         working-directory: ./www
       - run: npm test

--- a/www/package.json
+++ b/www/package.json
@@ -4,6 +4,9 @@
   "version": "0.1.0",
   "description": "Tsume-shogi Web Solver",
   "main": "dist/index.js",
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "#comment script-reference": "https://zenn.dev/sprout2000/articles/9d026d3d9e0e8f",
     "dev": "webpack serve --mode development",


### PR DESCRIPTION
## Summary
- add Node 22.x to www/package.json engines
- make the GitHub Pages workflow read Node from www/package.json
- keep TypeScript CI using package.json as the Node version source

## Tests
- npm ci
- npm run lint
- npm run test:prettier
- npm test -- --bail --maxWorkers=100% --watchAll=false