### PR TITLE
fix(deps): update brace-expansion lockfile entry

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -7533,9 +7533,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- update the vulnerable glob-nested brace-expansion lockfile entry from 2.1.0 to 2.1.2
- keep the change scoped to www/package-lock.json for Dependabot alert 158 / GHSA-3jxr-9vmj-r5cp

## Validation
- npm --prefix www ci
- npm --prefix www run lint
- npm --prefix www run test:prettier
- npm --prefix www test -- --bail --maxWorkers=100% --watchAll=false
- npm --prefix www run build